### PR TITLE
Memory leak: Thread is not deleted when uma0 is used

### DIFF
--- a/kernel/main.c
+++ b/kernel/main.c
@@ -888,6 +888,7 @@ int uma0_suspend_workaround_thread(SceSize args, void *argp) {
 	// this may look bad but the PSVita does this to detect ux0: so ¯\_(ツ)_/¯
 	if (!uma0_used) {
 		LOG("uma0: is not used: no need to remount it.\n");
+		ksceKernelExitDeleteThread(0);
 		return 0;
 	}
 	int i = 0;


### PR DESCRIPTION
I guess this PR doesn't need explanations. 
BTW the workaround function always fails on my vita 2004 with 3.65 firmware